### PR TITLE
Version 1.5

### DIFF
--- a/Hachure Generator.py
+++ b/Hachure Generator.py
@@ -1,6 +1,5 @@
 import math
 import statistics
-import time
 
 from collections import defaultdict
 
@@ -49,8 +48,10 @@ aspect_layer = QgsRasterLayer(
     processing.run('qgis:aspect', parameters)['OUTPUT'],'Aspect')
 
 parameters['INTERVAL'] = contour_interval
-filled_contours = QgsVectorLayer(processing.run('gdal:contour_polygon', parameters)['OUTPUT'], "Contour Layer", "ogr")
-line_contours = QgsVectorLayer(processing.run('gdal:contour', parameters)['OUTPUT'], "Contour Layer", "ogr")
+filled_contours = QgsVectorLayer(processing.run('gdal:contour_polygon',
+    parameters)['OUTPUT'], "Contour Layer", "ogr")
+line_contours = QgsVectorLayer(processing.run('gdal:contour',
+    parameters)['OUTPUT'], "Contour Layer", "ogr")
 
 
 #--------STEP 2: Set up variables & prepare rasters for reading---------
@@ -423,10 +424,12 @@ def hachure_generator(segment_list):
             value = sample_raster(rc,1) #get the aspect value
             slope = sample_raster(rc,0) #the slope, too
             if value == 0: # we're out of bounds of the raster
+                del line_coords[-1]
                 break
             
             if slope < min_slope:
                 #if we hit shallow slopes, lines should end
+                del line_coords[-1]
                 break
                 
             value += 180

--- a/Hachure Generator.py
+++ b/Hachure Generator.py
@@ -24,16 +24,21 @@ from qgis.core import (
 from qgis import processing
 
 #============================USER PARAMETERS============================
-#leave these 3 values at 1 to retain script defaults. Raise/lower them
-#to adjust those defaults (i.e., max_hachure_density = 2 will cause the
-# densest portion of the hachures to be twice the default)
+# These two params below are in DEM pixel units. So choosing 6 for the
+# max_hachure density means the script aims to make hachures 6 px apart
+# when the slope is at its minimum
 
-contour_density = 1
-min_hachure_density = 1
-max_hachure_density = 1
+min_hachure_spacing = 2
+max_hachure_spacing = 6
+
+spacing_checks = 100 
+# this parameter is how many times we check the hachure spacing
+# smaller number runs faster, but if lines are getting too close or too
+# far, it's not checking often enough
 
 min_slope = 15 #degrees
 max_slope = 40
+
 
 DEM = iface.activeLayer() #The layer of interest must be selected
 
@@ -41,8 +46,8 @@ DEM = iface.activeLayer() #The layer of interest must be selected
 #---------STEP 1: Get slope/aspect/contours using built in tools--------
 stats = DEM.dataProvider().bandStatistics(1)
 elevation_range = stats.maximumValue - stats.minimumValue
-contour_interval = elevation_range / 150 / contour_density
-#sets our default to 150 contour lines, adjusted by contour_density
+contour_interval = elevation_range / spacing_checks
+
 
 parameters = {
     'INPUT': DEM,
@@ -79,8 +84,8 @@ average_pixel_size = 0.5 * (slope_layer.rasterUnitsPerPixelX() +
                   slope_layer.rasterUnitsPerPixelY())
 jump_distance = average_pixel_size * 3
 
-min_spacing = average_pixel_size * 2 * min_hachure_density
-max_spacing = average_pixel_size * 6 * max_hachure_density
+min_spacing = average_pixel_size * min_hachure_density
+max_spacing = average_pixel_size * max_hachure_density
 
 spacing_range = max_spacing - min_spacing
 slope_range = max_slope - min_slope

--- a/README.md
+++ b/README.md
@@ -3,73 +3,77 @@ A QGIS method to generate automated hachure lines. Like these:
 
 ![image](https://github.com/pinakographos/Hachures/assets/5448396/4b00b0da-652b-4a5b-ad4a-5857c175b8c6)
 
-
 # Preamble
-This is version 1.0, and so I'm sure bugs & inefficiencies will be found. Meanwhile, the sample DEM (of Michigamme Mountain) that is included in this repo should succesfully generate hachures within several seconds on a modern computer using the default settings in the script.
+This is version 1.5, which means hopefully the most severe bugs have been quashed. Meanwhile, if you are stuck, try the sample DEM (of Michigamme Mountain) that is included in this repo. It should succesfully generate hachures within several seconds on a modern computer using the default settings in the script.
 
 Thanks to Nyall Dawson for some significant efficiency gains!
 
 # Advice
-I'll lead with some of my advice on using the script, and then later on we'll talk about how it works. First off, **be patient**. This script cantake a long time to run, depending on the settings. While a 1000 × 1000px raster with a handful of hachures may process in seconds, if you want a detailed set of lines on a large terrain, it could potentially run for a long time. Start small, and then work your way up to more detail and larger terrains once you get a sense of how long it will take.
+I'll lead with some of my advice on using the script, and then later on we'll talk about how it works. First off, **be patient**. This script can take a long time to run, depending on the settings. While a 1000 × 1000px raster with a handful of hachures may process in seconds, if you want a detailed set of lines on a large terrain, it could potentially run for a long time. Start small, and then work your way up to more detail and larger terrains once you get a sense of how long it will take.
 
-Second, you should have a reasonably smooth terrain to begin with. Hachures aren’t meant to show a huge amount of detail in a landform. They will gently bend if the terrain (and thus the aspect raster) are smooth. If the terrain is detailed, the hachures will be jagged. I also note that smoothing the raster tends to speed the whole script.
+Second, you should have a reasonably **smooth terrain** to begin with. Hachures aren’t meant to show a huge amount of detail in a landform. They will gently bend if the terrain is smooth. If the terrain is detailed, the hachures will be jagged. I also note that smoothing the raster tends to speed the whole script, though I am not wholly sure why.
 
 Finally, I often find the resulting hachures look best if you filter out some of the smallest stubs.
 
 # Walkthrough
-
 Ok, let's dive into a high-level review of how all this works. My method, built up organically over weeks of trial and error, is perhaps inelegant on account of the nature of its creation process, but it is effective. It is my hope that it will be a platform upon which others (perhaps including me) will build improved methods using fresh ideas.
 
 ## Initial Parameters
 The user must select a DEM raster layer (`iface.activeLayer()`). The script comes with some default parameters, but the user may choose to adjust them:
-+ `spacing_checks`: How many times the script will check that the hachures are properly spaced. Lowering this runs the script faster. But, it also makes hachure lines more likely to get closer or farther apart than they are supposed to. In reality, this parameter controls how many contour lines we generate across the vertical range of the DEM. Hachure spacing is checked every contour line.
++ `spacing_checks`: How many times the script will check that the hachures are properly spaced. Lowering this runs the script faster. But, it also makes hachure lines more likely to get closer or farther apart than they are supposed to. Behind the scenes, this parameter controls how many contour lines we generate across the vertical range of the DEM. Hachure spacing is checked every contour line.
 + `min_hachure_density` and `max_hachure_density`: These specify how close or how far apart we'd like our hachures to be. The units are the pixel size of the DEM.
 + `min_slope` and `max_slope` specify what slope levels we'll consider in making those hachures. The script makes hachures more dense when the slope of the terrain is higher, and spaces them out farther on shallower terrain. The closer a slope gets toward `max_slope`, the denser the hachures will be, up to `min_spacing`. If terrain has a slope that is less than `min_slope`, no hachures will be drawn in that area. If it has a slope equal to or greater than `max_slope`, hachures will be at maximum density (spaced according to `min_spacing`).
 
 ## Generate Raster Derivaties
-First off, we take our DEM and generate slope and aspect rasters, as well as a contour polygon layer, using QGIS's existing processes.
-The `contour_interval` parameter sets the contour interval, in the DEM's Z units.
+First off, we take our DEM and generate four derivaties:
+1. Slope raster
+2. Aspect raster
+3. Contour polygon layer
+4. Contour line layer
+For 3 & 4, the script will set the contour interval so that the number of contours generated matches `spacing_checks`.
 <img width="1472" alt="image" src="https://github.com/pinakographos/Hachures/assets/5448396/3bcf2980-1fd8-4a3e-acb5-ff8396d34b23">
 
 ## Contour Poly Reformatting
-The hachure script presently requires that the contours be in a particular format. Initially, the contour polys that we generated show all elevations between two specific values. 
+Some retooling of our contours is needed before they are ready. First, the contour lines are dissolved based on their elevation, so that each elevation level has only one feature, which might contain multiple contour rings.
+
+The script primarily uses these contour lines. But, there is one piece of information that they cannot provide, and which the script will need: for a given contour line, without any external information, you cannot tell which areas are _higher_ and which are _lower_ that the elevation of that line.
+
+To fix this, we take our contour polygons and do some processing. Initially, these polys show all elevations between two specific values. 
 <img width="1331" alt="image" src="https://github.com/pinakographos/Hachures/assets/5448396/6018a802-2fc9-4de3-9904-d82edf11f7ed">
 
-However, for the hachure process to work, reformatting is needed. For each contour level, we need to generate a polygon that shows all areas that are **higher** than that elevation.
+However, for each contour level, we need to generate a polygon that shows all areas that are **higher** than that elevation.
 <img width="1307" alt="image" src="https://github.com/pinakographos/Hachures/assets/5448396/d4517c19-50e9-4044-b603-3ca877206e49">
 
-This is done in the script by creating a simple rectangle that matches the bounds of the contour layer. For each contour polygon, we subtract it, and all other contours lower than it, from the rectangle poly, using the `difference` geometry method. This yields the result we want, as seen in the example above. Finally, we convert those polygons to lines. This yields what the hachure tool requires: closed contours, where the inside of each closure represents all elevations above that contour's value.
+This is done in the script by creating a simple rectangle that matches the bounds of the contour layer. For each contour polygon, we subtract it, and all other contours lower than it, from the rectangle poly, using the `difference` geometry method. This yields the result we want, as seen in the example above. Within the script, we store the polygon and contour line together, so that for any given contour line, we can look up the polygon that shows all areas that are higher elevation than that line.
 
 Now we are ready to begin hachure generation through the main loop of the script.
 
 ## Contour Splitting
-The script iterates through the contour lines, starting with the lowest-elevation one. Based on how we generated these, this will be a closed loop (or set of closed loops) that, in polygon form, cover all areas **higher** than our contour's elevation.
-
-We begin by dividing this contour line into chunks, each being `max_spacing * 3` in width. This choice is somewhat arbitrary on my part, but the results seem to work pleasantly enough.
+The script iterates through the contour lines, starting with the lowest-elevation one. We begin by dividing this contour line into chunks, each being `max_spacing * 3` in width (and remember, `max_hachure_spacing` is in units of the DEM's pixels, so that if the DEM pixel width is 12 meters for example, and `max_hachure_spacing` is 3, then `max_hachure_spacing` represents 36 meters). This choice of multiplying by 3 is somewhat arbitrary on my part, but the results seem to work pleasantly enough.
 
 <img width="705" alt="image" src="https://github.com/pinakographos/Hachures/assets/5448396/b858a338-496d-400a-bed0-c5ae46d8c232">
 
-Each split chunk is then densified with extra vertices (spaced according to the pixel size of the slope raster). We use each vertex to sample the slope raster, and average the result. So now we know the average slope covered by each chunk, and store that on the chunk.
+Each chunk is then densified with extra vertices (spaced according to the pixel size of the slope raster). We use each vertex to sample the slope raster, and average the result. So now we know the average slope covered by each chunk, and store that on the chunk.
 
 ## Contours to Dashes
-Using this slope information, along with the user parameters, we can determine how many hachures should pass through the zone covered by this particular chunk of a contour line (which the script calls a `Segment`). Its average slope is compared to the `max_slope` and `min_slope`, and we use the `min_spacing` and `max_spacing` parameters to determine how dense the hachures should be here. Let's say that we have the following parameters:
-+ `min_spacing = 2`
-+ `max_spacing = 10`
+Using this slope information, along with the user parameters, we can determine how many hachures should pass through the zone covered by this particular chunk of a contour line (which the script calls a `Segment`). Its average slope is compared to the `max_slope` and `min_slope`, and we use the `min_hachure_spacing` and `max_hachure_spacing` parameters to determine how dense the hachures should be here. Let's say that we have the following parameters:
++ `min_hachure_spacing = 2`
++ `max_hachure_spacing = 10`
 + `min_slope = 10`
 + `max_slope = 45`
 
-And let's say our segment has an average slope of 35°. That slope of 35° is about 71% of the way from 10° to 45° ((35 - 10) / (45 - 10)). We take that percentage back to our spacing parameters and find the spacing that is 71% of the way between 2 and 10. And here, denser spacing = more slope, so we want the value that is closer to 2 than 10. We get a value of 10 - ((10 - 2) * 0.71) = 4.3. This is our final `spacing` value for our example segment. We take that segment and split it into a series of dashes and gaps, each 4.3 map units in length.
+And let's say our segment has an average slope of 35°. That slope of 35° is about 71% of the way from 10° to 45° ((35 - 10) / (45 - 10)). We take that percentage back to our spacing parameters and find the spacing that is 71% of the way between 2 and 10. And here, denser spacing = more slope, so we want the value that is closer to 2 than 10. We get a value of 10 - ((10 - 2) * 0.71) = 4.3. This is our final `spacing` value (in pixels) for our example segment. We take that segment and split it into a series of dashes and gaps, each 4.3 pixels in length.
 
 We repeat this process for each of the segments, until each is split into dashes and gaps, and the size of those dashes/gaps varies according to our underlying slope and our user parameters of how much min/max spacing we want. If a segment's slope is less than `min_slope`, we eliminate it.
 
 <img width="735" alt="image" src="https://github.com/pinakographos/Hachures/assets/5448396/d9331072-a77f-44a3-b118-d900771cd230">
 
-This is why I initially split the line into chunks that are `max_spacing * 3` long. It makes them wide enough that there will be room for a few dashes/gaps, while keeping it small enough to also make sure that it reflects a **local** slope value
+This is why I initially split the line into chunks that are `max_hachure_spacing * 3` long. It makes them wide enough that there will be room for a few dashes/gaps, while keeping it small enough to also make sure that it reflects a **local** slope value
 
-These dashes/gaps (which are adjusted a bit in length based on the length of the actual segment) are used to generate hachures.
+These dashes/gaps (which are adjusted a bit in length based on the length of the actual segment) are next used to generate hachures.
 
 ## Hachure Generation
-To begin, we generate a point at the center of each dash. We use that as a starting point for drawing each of our initial set of hachure lines. We look at the aspect raster that was generated earlier, and use this to determine which direction to run these hachure lines (up/down the slope) using some trigonometry (and luck on my part, as far as remembering how trigonometry works). The trig functions tell us what direction the line should run. We jump 3 pixels in that direction and then sample the aspect raster again, then jump another 2 pixels along, etc. 
+To begin, we generate a point at the center of each dash. Our hachure lines will grow out of these points, being drawn in an up-slope direction. To begin, we sample the aspect raster and use some trigonometry to calculate which direction is up-slope. We then jump 3 pixels in that direction and then sample the aspect raster again, then jump another 3 pixels up-slope, etc. Connecting the dots, we get a line that runs up the slope: a hachure line.
 
 <img width="1336" alt="image" src="https://github.com/pinakographos/Hachures/assets/5448396/3c2d7ddc-afac-44db-b70b-5025214e96c1">
 
@@ -79,27 +83,26 @@ The line stops when it hits a shallow slope, or starts to bounce around a sink, 
 
 This hachure generation setup is very akin to some hydrological modelling. I originally experimented with using a flow direction raster, in which each pixel specifies which of its 8 neighboring pixels water would flow into if headed downhill. But, with only 8 directions to choose from, the results were rather jagged, vs. the aspect raster which can have any angle value to specify our next direction (which we take advantage of by skipping a couple pixels over before sampling again). It may still be worth exploring someday — perhaps generating a flow raster as a standalone internal feature in the script, and smoothing out the jagged lines afterwards.
 
-We then store our current set of hachures and move on to the next contour line in the sequence.
+Once we've grown a hachure line from each dash, we store the set of them and move on to the next contour line in the sequence.
 
 Before moving on, I want to note that the reason for starting hachures at these dashes is that making a set of dashes and gaps is used to enforce a **minimum** spacing between hachures. The gaps and dashes ensure that they cannot get too close.
 
 ## Continuing Upwards
 
-We now move on to the **next** contour line (the second-lowest one). For this line, and any subsequent ones, there are a couple of changes to the procedure.
+We now move on to the **next** contour line (the second-lowest one). For this line, and any subsequent ones, the procedure is somewhat different.
 
-For the next contour, we first split it based on its intersections with the hachures retained from the prior contour layer(s). Then any large segments are once again split by maximum length (again, `max_spacing * 3`).
+For the next contour, we first split it based on its intersections with the hachures retained from the prior contour layer(s). Then any large segments are once again split by maximum length (again, `max_hachure_spacing * 3`).
 
 <img width="1340" alt="image" src="https://github.com/pinakographos/Hachures/assets/5448396/5f86214d-06e5-4942-bdb0-c32733e43a83">
 
-Then we look through each contour segment, get its average slope, and once again run the `spacing` calculation to determine how far apart hachures should be in this area based on the underlying slope. This time we take some extra steps. Many of the contour segments seen above are touched on each end by a hachure; remember the contours were divided by the hachures (and by `max_spacing`). So, the length of that contour segment encodes how close together the hachures are. If a contour's ideal spacing (based on the underling slope) is larger than its length, that means that the two hachures that touch it are **too close together** now according to the underlying slope. We should trim at least one of them off. We look at both hachures and determine which is the longest, and keep that one and stop the other one here, at this contour. I have prioritized the longest hachures for continuity. But it would probably look fine if the shortest hachures or random ones were kept instead.
-
-If the local slope is below `min_slope`, we cut off both as this is an area with a gradual enough slope that no hachures should be shown. Here we can see in the middle how one line got cut off:
+Then we look through each contour segment, get its average slope, and once again run the `spacing` calculation to determine how far apart hachures should be in this area based on the underlying slope. This time we take some extra steps. Many of the contour segments seen above are touched on each end by a hachure; remember the contours were divided by the hachures (and by `max_hachure_spacing`). So, the length of that contour segment encodes _how close together the hachures are_. If a contour's ideal spacing (based on the underlying slope) is larger than its length, that means that the two hachures that touch it are **too close together** now according to the underlying slope. We should trim one of them off, so that it stops at this contour and does not continue up-slope.
+, and the choice is made at random (which ended up looking better than choosing the longest one). If the local slope is below `min_slope`, we cut off both as this is an area with a gradual enough slope that no hachures should be shown. Here we can see in the middle how one line got cut off:
 
 <img width="508" alt="image" src="https://github.com/pinakographos/Hachures/assets/5448396/5b93119a-b06e-4b66-900f-9dff1cb81f50">
 
-It started at the outer contour and when it was checked against the next contour on the inside, that slope was too shallow and it was time to cut the line off, while some other lines nearby continued.
+It started at the outer contour and when it was checked against the next contour on the inside, that slope was too shallow and it was time to cut the line off, while some other lines nearby continued. This cut is made using the contour polygons we prepared earlier. Since our hachure passes through the contour, it can tell us which part of the hachure to delete and which to keep, because it encodes which areas are up-slope vs. down-slope of this hachure.
 
-The script can also determine which contour segments are **too long**. If a segments touches 2 hachures and is longer than its preferred spacing, it means those hachures have drifted too far apart for their current slope. We need to start at least 1 new line along this segment. This is done much as it is above: we split that segments into dashes based on its slope, and then begin new hachures at the center of each dash.
+The script can also determine which contour segments are **too long**. If a segments touches 2 hachures and is longer than its preferred spacing, it means those hachures have drifted too far apart for their current slope. We need to start at least 1 new line along this segment. This is done much as it is in the section above: we split that segment into dashes based on its slope, and then begin new hachures at the center of each dash.
 
 Finally, some contour segments may not touch any hachures, in which case we treat them as normal and split them into varying dash lengths based on the slope, and then give them a line running through each dash.
 
@@ -107,9 +110,7 @@ Iterating through the entire set of contours, we get a set of hachures. They get
 
 <img width="486" alt="image" src="https://github.com/pinakographos/Hachures/assets/5448396/278f4127-dfae-443a-93b3-82075ea807b8">
 
-
 ### Final Thoughts 
-A denser `contour_interval` means lines are trimmed/begun more often, because we check their spacing at each contour. This comes at a cost of more computation time, though. Irregular contour intervals would work here, too; it's not important that the contours be evenly spaced.
 Near the edges of a DEM, you might get some odd hachure lines. I recommend generating hachures on a slightly larger area than you need them. I also usually filter out the shortest stub hachures for a more visually pleasing result.
 
 Getting a good result takes time and iteration. While the example DEM can be processed in seconds with the default script settings, larger terrains and/or greater hachure density will slow things down. It's possible to cause the script to run for hours with the right settings. For large and/or high-detail areas, I recommend starting small (less detail or a smaller raster) to experiment first and find the settings you want, before doing a long run.

--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@ A QGIS method to generate automated hachure lines. Like these:
 
 
 # Preamble
-This is version 1.0, and so I'm sure bugs & inefficiencies will be found. Meanwhile, the sample DEM (of Michigamme Mountain) that is included in this repo should succesfully generate hachures within a few seconds on a modern computer using the default settings in the script.
+This is version 1.0, and so I'm sure bugs & inefficiencies will be found. Meanwhile, the sample DEM (of Michigamme Mountain) that is included in this repo should succesfully generate hachures within several seconds on a modern computer using the default settings in the script.
 
 Thanks to Nyall Dawson for some significant efficiency gains!
 
 # Advice
-I'll lead with some of my advice on using the script, and then later on we'll talk about how it works. First off, **be patient**. This script cantake a long time to run, depending on the settings. While a 1000 × 1000px raster with a handful of hachures may process in seconds, if you want a detailed set of lines on a large terrain, it could potentially run for tens of minutes, or even stretch into hours. Start small, and then work your way up.
+I'll lead with some of my advice on using the script, and then later on we'll talk about how it works. First off, **be patient**. This script cantake a long time to run, depending on the settings. While a 1000 × 1000px raster with a handful of hachures may process in seconds, if you want a detailed set of lines on a large terrain, it could potentially run for a long time. Start small, and then work your way up to more detail and larger terrains once you get a sense of how long it will take.
 
 Second, you should have a reasonably smooth terrain to begin with. Hachures aren’t meant to show a huge amount of detail in a landform. They will gently bend if the terrain (and thus the aspect raster) are smooth. If the terrain is detailed, the hachures will be jagged. I also note that smoothing the raster tends to speed the whole script.
 
@@ -21,10 +21,9 @@ Finally, I often find the resulting hachures look best if you filter out some of
 Ok, let's dive into a high-level review of how all this works. My method, built up organically over weeks of trial and error, is perhaps inelegant on account of the nature of its creation process, but it is effective. It is my hope that it will be a platform upon which others (perhaps including me) will build improved methods using fresh ideas.
 
 ## Initial Parameters
-The user must select a DEM raster layer (`iface.activeLayer()`). They should also fill in a few parameters:
-
-+ `contour_interval`. This script generates contour lines, and checks our hachure lines (more on that below) every contour.
-+ `min_spacing` and `max_spacing` specify, in map units, how close or how far apart we'd like our hachures to be.
+The user must select a DEM raster layer (`iface.activeLayer()`). The script comes with some default parameters, but the user may choose to adjust them:
++ `spacing_checks`: How many times the script will check that the hachures are properly spaced. Lowering this runs the script faster. But, it also makes hachure lines more likely to get closer or farther apart than they are supposed to. In reality, this parameter controls how many contour lines we generate across the vertical range of the DEM. Hachure spacing is checked every contour line.
++ `min_hachure_density` and `max_hachure_density`: These specify how close or how far apart we'd like our hachures to be. The units are the pixel size of the DEM.
 + `min_slope` and `max_slope` specify what slope levels we'll consider in making those hachures. The script makes hachures more dense when the slope of the terrain is higher, and spaces them out farther on shallower terrain. The closer a slope gets toward `max_slope`, the denser the hachures will be, up to `min_spacing`. If terrain has a slope that is less than `min_slope`, no hachures will be drawn in that area. If it has a slope equal to or greater than `max_slope`, hachures will be at maximum density (spaced according to `min_spacing`).
 
 ## Generate Raster Derivaties

--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # Hachures
 A QGIS method to generate automated hachure lines. Like these:
 
-![image](https://github.com/pinakographos/Hachures/assets/5448396/4b00b0da-652b-4a5b-ad4a-5857c175b8c6)
+<img width="1335" alt="image" src="https://github.com/user-attachments/assets/d4136616-3b73-42eb-8bbd-338f72bc249b">
+
 
 # Preamble
 This is version 1.5, which means hopefully the most severe bugs have been quashed. Meanwhile, if you are stuck, try the sample DEM (of Michigamme Mountain) that is included in this repo. It should succesfully generate hachures within several seconds on a modern computer using the default settings in the script.
 
-Thanks to Nyall Dawson for some significant efficiency gains!
+Thanks to Nyall Dawson for guiding me toward some significant efficiency gains!
 
 # Advice
 I'll lead with some of my advice on using the script, and then later on we'll talk about how it works. First off, **be patient**. This script can take a long time to run, depending on the settings. While a 1000 × 1000px raster with a handful of hachures may process in seconds, if you want a detailed set of lines on a large terrain, it could potentially run for a long time. Start small, and then work your way up to more detail and larger terrains once you get a sense of how long it will take.
@@ -22,7 +23,7 @@ Ok, let's dive into a high-level review of how all this works. My method, built 
 The user must select a DEM raster layer (`iface.activeLayer()`). The script comes with some default parameters, but the user may choose to adjust them:
 + `spacing_checks`: How many times the script will check that the hachures are properly spaced. Lowering this runs the script faster. But, it also makes hachure lines more likely to get closer or farther apart than they are supposed to. Behind the scenes, this parameter controls how many contour lines we generate across the vertical range of the DEM. Hachure spacing is checked every contour line.
 + `min_hachure_density` and `max_hachure_density`: These specify how close or how far apart we'd like our hachures to be. The units are the pixel size of the DEM.
-+ `min_slope` and `max_slope` specify what slope levels we'll consider in making those hachures. The script makes hachures more dense when the slope of the terrain is higher, and spaces them out farther on shallower terrain. The closer a slope gets toward `max_slope`, the denser the hachures will be, up to `min_spacing`. If terrain has a slope that is less than `min_slope`, no hachures will be drawn in that area. If it has a slope equal to or greater than `max_slope`, hachures will be at maximum density (spaced according to `min_spacing`).
++ `min_slope` and `max_slope` specify what slope levels we'll consider in making those hachures. The script makes hachures more dense when the slope of the terrain is higher, and spaces them out farther on shallower terrain. The closer a slope gets toward `max_slope`, the denser the hachures will be, up to `min_hachure_spacing`. If terrain has a slope that is less than `min_slope`, no hachures will be drawn in that area. If it has a slope equal to or greater than `max_slope`, hachures will be at maximum density (spaced according to `min_hachure_spacing`).
 
 ## Generate Raster Derivaties
 First off, we take our DEM and generate four derivaties:
@@ -31,7 +32,9 @@ First off, we take our DEM and generate four derivaties:
 3. Contour polygon layer
 4. Contour line layer
 For 3 & 4, the script will set the contour interval so that the number of contours generated matches `spacing_checks`.
-<img width="1472" alt="image" src="https://github.com/pinakographos/Hachures/assets/5448396/3bcf2980-1fd8-4a3e-acb5-ff8396d34b23">
+
+<img width="1322" alt="image" src="https://github.com/user-attachments/assets/b896f8df-1056-4eb9-8c9c-45e6be058db5">
+
 
 ## Contour Poly Reformatting
 Some retooling of our contours is needed before they are ready. First, the contour lines are dissolved based on their elevation, so that each elevation level has only one feature, which might contain multiple contour rings.
@@ -49,7 +52,7 @@ This is done in the script by creating a simple rectangle that matches the bound
 Now we are ready to begin hachure generation through the main loop of the script.
 
 ## Contour Splitting
-The script iterates through the contour lines, starting with the lowest-elevation one. We begin by dividing this contour line into chunks, each being `max_spacing * 3` in width (and remember, `max_hachure_spacing` is in units of the DEM's pixels, so that if the DEM pixel width is 12 meters for example, and `max_hachure_spacing` is 3, then `max_hachure_spacing` represents 36 meters). This choice of multiplying by 3 is somewhat arbitrary on my part, but the results seem to work pleasantly enough.
+The script iterates through the contour lines, starting with the lowest-elevation one. We begin by dividing this contour line into chunks, each being `max_hachure_spacing * 3` in width (and remember, `max_hachure_spacing` is in units of the DEM's pixels, so that if the DEM pixel width is 12 meters for example, and `max_hachure_spacing` is 3, then `max_hachure_spacing` represents 36 meters). This choice of multiplying by 3 is somewhat arbitrary on my part, but the results seem to work pleasantly enough.
 
 <img width="705" alt="image" src="https://github.com/pinakographos/Hachures/assets/5448396/b858a338-496d-400a-bed0-c5ae46d8c232">
 


### PR DESCRIPTION
This incorporates a variety of hachure cleanups (which incidentally leads to yet more performance gains). Takes care of issues #5, #6, and #7, as well as other bugs that I didn't create issues for.

- Hachure lines no longer go out of bounds. 
- Contour lines no longer are generated from polys, so there are no contour segments that are simply running along the edge of the DEM. Thus when contour lines are split for hachure checking or generation, they no longer have to bother checking those areas. These two fixes together clear up #6 and #5.
- Default parameters added and user parameters tweaked so that you'll get a better experience out of the box
- Adjusted settings for when lines get cut off or generated, to solve #7.
- Output hachures now have a length field so they can be quickly filtered by the user (as is recommended in the ReadMe)
- No longer prioritizing longest hachure when choosing which to cut. Now it's random. This prevents weird-looking results like this, where one hachure goes a long ways uphill while its neighbors are shorter: 
<img width="114" alt="image" src="https://github.com/user-attachments/assets/2a1854dc-76d3-44b9-8e81-d87e510eaf33">